### PR TITLE
UI Update - Sample Documents Buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.swp
 venv/
 server/userData/*
+.idea

--- a/server/static/index.html
+++ b/server/static/index.html
@@ -42,8 +42,8 @@
               <span class="btn btn-default btn-sm topicWord draggable" ng-repeat="word in anchorObj.topic" draggable="true" ondragstart="drag(event)" id="topic{{$parent.$index}}Word{{this.$index}}">{{word}}</span>
             </div>
           </div>
-          <div class="col-sm-1 col-md-1 col-lg-1 col-xs-12" ng-show="ctrl.noChangesYet">
-            <button type="button" id="show-docs-button-{{this.$index}}" class="btn show-docs-button" ng-click="ctrl.getRelatedDocuments($index)"><img src="docs_black.svg"></button>
+          <div class="col-sm-1 col-md-1 col-lg-1 col-xs-12">
+            <button type="button" id="show-docs-button-{{this.$index}}" class="btn show-docs-button" ng-disabled="!ctrl.noChangesYet" ng-click="ctrl.getRelatedDocuments($index)"><img src="docs_black.svg"></button>
           </div>
         </div>
       </div>

--- a/server/static/index.html
+++ b/server/static/index.html
@@ -42,7 +42,7 @@
               <span class="btn btn-default btn-sm topicWord draggable" ng-repeat="word in anchorObj.topic" draggable="true" ondragstart="drag(event)" id="topic{{$parent.$index}}Word{{this.$index}}">{{word}}</span>
             </div>
           </div>
-          <div class="col-sm-1 col-md-1 col-lg-1 col-xs-12">
+          <div class="col-sm-1 col-md-1 col-lg-1 col-xs-12" ng-mouseenter="ctrl.popoverIfDisabled($index)">
             <button type="button" id="show-docs-button-{{this.$index}}" class="btn show-docs-button" ng-disabled="!ctrl.noChangesYet" ng-click="ctrl.getRelatedDocuments($index)"><img src="docs_black.svg"></button>
           </div>
         </div>

--- a/server/static/index.html
+++ b/server/static/index.html
@@ -42,7 +42,7 @@
               <span class="btn btn-default btn-sm topicWord draggable" ng-repeat="word in anchorObj.topic" draggable="true" ondragstart="drag(event)" id="topic{{$parent.$index}}Word{{this.$index}}">{{word}}</span>
             </div>
           </div>
-          <div class="col-sm-1 col-md-1 col-lg-1 col-xs-12" ng-mouseenter="ctrl.popoverIfDisabled($index)">
+          <div class="col-sm-1 col-md-1 col-lg-1 col-xs-12" ng-mouseover="ctrl.popoverIfDisabled($index)" ng-mouseleave="ctrl.closePopover($index)">
             <button type="button" id="show-docs-button-{{this.$index}}" class="btn show-docs-button" ng-disabled="!ctrl.noChangesYet" ng-click="ctrl.getRelatedDocuments($index)"><img src="docs_black.svg"></button>
           </div>
         </div>

--- a/server/static/scripts/script.js
+++ b/server/static/scripts/script.js
@@ -400,21 +400,22 @@ var app = angular.module('anchorApp', [])
           ctrl.showSampleDocuments = true
         }
 
-        ctrl.popoverIfDisabled = function popoverIfDisabled(index) {
+        ctrl.popoverIfDisabled = function(index) {
             var selector = "#show-docs-button-" + index
-            var coke = $(selector)
-            var disabled = coke.prop('disabled')
-            console.log("disabled", selector, disabled)
-            coke.popover()
+            var btn = $(selector)
+            var disabled = btn.prop('disabled')
+            btn.popover()
             if (disabled) {
-                var parent = coke.parent()
-                console.log("parent", parent)
+                var parent = btn.parent()
                 parent.popover({
                     placement: 'bottom',
                     trigger: 'manual',
                     html: true,
-                    content: 'You cannot click me!'
+                    content: 'Click `Update Topics` to sample new documents.'
                 }).popover('show')
+                $timeout(function() {
+                    ctrl.closePopover(index)
+                }, 3000)
             }
         }
 

--- a/server/static/scripts/script.js
+++ b/server/static/scripts/script.js
@@ -403,14 +403,26 @@ var app = angular.module('anchorApp', [])
         ctrl.popoverIfDisabled = function popoverIfDisabled(index) {
             var selector = "#show-docs-button-" + index
             var coke = $(selector)
-            console.log("disabled", selector, coke, $(selector).prop('disabled'))
-            coke.popover({
-            placement:'bottom',
-            trigger:'manual',
-            html:true,
-            content:'Click me to see sample documents for this topic.'
-          })
+            var disabled = coke.prop('disabled')
+            console.log("disabled", selector, disabled)
+            coke.popover()
+            if (disabled) {
+                var parent = coke.parent()
+                console.log("parent", parent)
+                parent.popover({
+                    placement: 'bottom',
+                    trigger: 'manual',
+                    html: true,
+                    content: 'You cannot click me!'
+                }).popover('show')
+            }
         }
+
+      ctrl.closePopover = function closePopover(index) {
+          var selector = "#show-docs-button-" + index
+          var coke = $(selector)
+          coke.parent().popover('hide')
+      }
 
 
 //        // This allows documents and corresponding topics to highlight when

--- a/server/static/scripts/script.js
+++ b/server/static/scripts/script.js
@@ -404,14 +404,22 @@ var app = angular.module('anchorApp', [])
             var selector = "#show-docs-button-" + index
             var btn = $(selector)
             var disabled = btn.prop('disabled')
+            var anyOpen = false
+            $("[id^=show-docs-button-]").each(function() {
+                var pop = $(this).parent().data('bs.popover')
+                if (pop !== undefined)
+                {
+                    anyOpen = pop.tip().hasClass('in')
+                }
+            })
             btn.popover()
-            if (disabled) {
+            if (disabled && !anyOpen) {
                 var parent = btn.parent()
                 parent.popover({
                     placement: 'bottom',
                     trigger: 'manual',
                     html: true,
-                    content: 'Click `Update Topics` to sample new documents.'
+                    content: 'Click "Update Topics" to sample new documents.'
                 }).popover('show')
                 $timeout(function() {
                     ctrl.closePopover(index)
@@ -422,7 +430,7 @@ var app = angular.module('anchorApp', [])
       ctrl.closePopover = function closePopover(index) {
           var selector = "#show-docs-button-" + index
           var coke = $(selector)
-          coke.parent().popover('hide')
+          coke.parent().popover('destroy')
       }
 
 

--- a/server/static/scripts/script.js
+++ b/server/static/scripts/script.js
@@ -199,7 +199,7 @@ var app = angular.module('anchorApp', [])
             content:'Click me to see sample documents for this topic.'
           }).popover('show')
           $timeout(function() {
-            $("#show-docs-button-0").popover('hide')
+              $("#show-docs-button-0").popover('hide')
           }, 2000)
         }
 
@@ -387,7 +387,7 @@ var app = angular.module('anchorApp', [])
           ctrl.showSampleDocuments = false
         }
 
-  
+
         ctrl.showSampleDocuments = false
 
         ctrl.topicDocuments = []
@@ -398,6 +398,18 @@ var app = angular.module('anchorApp', [])
         ctrl.getRelatedDocuments = function getRelatedDocuments(index) {
           ctrl.topicDocuments = ctrl.documents[index]
           ctrl.showSampleDocuments = true
+        }
+
+        ctrl.popoverIfDisabled = function popoverIfDisabled(index) {
+            var selector = "#show-docs-button-" + index
+            var coke = $(selector)
+            console.log("disabled", selector, coke, $(selector).prop('disabled'))
+            coke.popover({
+            placement:'bottom',
+            trigger:'manual',
+            html:true,
+            content:'Click me to see sample documents for this topic.'
+          })
         }
 
 
@@ -509,6 +521,31 @@ app.directive("autocomplete", function() {
   }
 })
 
+// app.directive('tooltip', function () {
+//     return {
+//         restrict:'A',
+//         link: function(scope, element, attrs)
+//         {
+//             var pop = {
+//                     placement:'bottom',
+//                     trigger:'manual',
+//                     html:true,
+//                     content:'You found Me!'
+//                 }
+//             var parent = $(element).parent()
+//             parent.popover(pop)
+//             $(element).onmouseover = function () {
+//                 console.log("disabled", element.disabled)
+//                 if (element.disabled)
+//                 {
+//                     $(parent).popover('show')
+//                 }
+//             }
+//             console.log("parent", parent)
+//             scope.$apply()
+//         }
+//     }
+// })
 
 //This function returns an array of anchor objects from arrays of anchors and topics.
 //Anchor objects hold both anchor words and topic words related to the anchor words.


### PR DESCRIPTION
# UI Fixes:
- [x] Sample documents buttons no longer disappear after a change, but instead become disabled
- [x] If disabled, buttons will display a popover when hovered over that tells them to click the `Update Topics` button
- [x] buttons will (generally) only display one such popover at a time
