### PR TITLE
Terminate exponentiated gradient descent early

### DIFF
--- a/ankura/topic.py
+++ b/ankura/topic.py
@@ -16,6 +16,7 @@ def logsum_exp(y):
 
 _C1 = 1e-4
 _C2 = .75
+HISTORY_SIZE = 50
 
 def exponentiated_gradient(Y, X, XX, epsilon):
     """Solves an exponentied gradient problem with L2 divergence"""
@@ -39,9 +40,11 @@ def exponentiated_gradient(Y, X, XX, epsilon):
     # Initialize book keeping
     stepsize = 1
     decreased = False
+    prev_convergence = float('inf')
     convergence = float('inf')
+    same_count = 0
 
-    while convergence >= epsilon:
+    while convergence >= epsilon and same_count < HISTORY_SIZE:
         old_obj = new_obj
         old_alpha = numpy.copy(alpha)
         old_log_alpha = numpy.copy(log_alpha)
@@ -82,7 +85,12 @@ def exponentiated_gradient(Y, X, XX, epsilon):
 
         # Update book keeping
         decreased = False
+        prev_convergence = convergence
         convergence = numpy.dot(alpha, grad - grad.min())
+        if prev_convergence == convergence:
+            same_count += 1
+        else:
+            same_count = 0
 
     return alpha
 

--- a/ankura/topic.py
+++ b/ankura/topic.py
@@ -16,7 +16,6 @@ def logsum_exp(y):
 
 _C1 = 1e-4
 _C2 = .75
-HISTORY_SIZE = 50
 
 def exponentiated_gradient(Y, X, XX, epsilon):
     """Solves an exponentied gradient problem with L2 divergence"""
@@ -40,11 +39,10 @@ def exponentiated_gradient(Y, X, XX, epsilon):
     # Initialize book keeping
     stepsize = 1
     decreased = False
-    prev_convergence = float('inf')
+    prev_convergence = float('-inf')
     convergence = float('inf')
-    same_count = 0
 
-    while convergence >= epsilon and same_count < HISTORY_SIZE:
+    while convergence >= epsilon:
         old_obj = new_obj
         old_alpha = numpy.copy(alpha)
         old_log_alpha = numpy.copy(log_alpha)
@@ -63,7 +61,8 @@ def exponentiated_gradient(Y, X, XX, epsilon):
 
         # See if stepsize should decrease
         old_obj, new_obj = new_obj, AXXA - 2 * AXY + YY
-        if new_obj > old_obj + _C1 * stepsize * numpy.dot(grad, alpha - old_alpha):
+        new_obj_threshold = old_obj + _C1 * stepsize * numpy.dot(grad, alpha - old_alpha)
+        if new_obj > new_obj_threshold or prev_convergence == convergence:
             stepsize /= 2.0
             alpha = old_alpha
             log_alpha = old_log_alpha
@@ -87,10 +86,6 @@ def exponentiated_gradient(Y, X, XX, epsilon):
         decreased = False
         prev_convergence = convergence
         convergence = numpy.dot(alpha, grad - grad.min())
-        if prev_convergence == convergence:
-            same_count += 1
-        else:
-            same_count = 0
 
     return alpha
 


### PR DESCRIPTION
Sometimes, exponentiated gradient descent will run indefinitely because
the convergence value stops changing at some value greater than the
epsilon.  This patch will terminate exponentiated gradient descent if
the last 50 iterations have had the same convergence value.