### PR TITLE
Fix for exponentiated gradient descent

### DIFF
--- a/ankura/topic.py
+++ b/ankura/topic.py
@@ -39,7 +39,6 @@ def exponentiated_gradient(Y, X, XX, epsilon):
     # Initialize book keeping
     stepsize = 1
     decreased = False
-    prev_convergence = float('-inf')
     convergence = float('inf')
 
     while convergence >= epsilon:
@@ -61,8 +60,9 @@ def exponentiated_gradient(Y, X, XX, epsilon):
 
         # See if stepsize should decrease
         old_obj, new_obj = new_obj, AXXA - 2 * AXY + YY
-        new_obj_threshold = old_obj + _C1 * stepsize * numpy.dot(grad, alpha - old_alpha)
-        if new_obj > new_obj_threshold or prev_convergence == convergence:
+        offset = _C1 * stepsize * numpy.dot(grad, alpha - old_alpha)
+        new_obj_threshold = old_obj + offset
+        if new_obj >= new_obj_threshold:
             stepsize /= 2.0
             alpha = old_alpha
             log_alpha = old_log_alpha
@@ -84,7 +84,6 @@ def exponentiated_gradient(Y, X, XX, epsilon):
 
         # Update book keeping
         decreased = False
-        prev_convergence = convergence
         convergence = numpy.dot(alpha, grad - grad.min())
 
     return alpha


### PR DESCRIPTION
We decided that our previous fix for exponentiated gradient descent was
incorrect.  This fix forces the step size to eventually reach zero in
the pathological case where precision error failed to induce a step size
change.