### PR TITLE
using posixpath in _url function for Windows compatibility

### DIFF
--- a/ankura/corpus.py
+++ b/ankura/corpus.py
@@ -17,6 +17,7 @@ import os
 import urllib.request
 
 from . import pipeline
+import posixpath
 
 download_dir = os.path.join(os.getenv('HOME'), '.ankura')
 
@@ -27,7 +28,7 @@ def _path(name):
 base_url = 'https://github.com/jefflund/data/raw/data2'
 
 def _url(name):
-    return os.path.join(base_url, name)
+    return posixpath.join(base_url, name)
 
 
 def _ensure_dir(path):


### PR DESCRIPTION
On Windows, os.path.join() joins path elements with a backslash, which causes an error when constructing a URL. By using posixpath to join path elements in the _url function, we can avoid causing an error on Windows systems.