### PR TITLE
Fixed the normalization of unlabeled documents

### DIFF
--- a/ankura/anchor.py
+++ b/ankura/anchor.py
@@ -115,7 +115,7 @@ def build_labeled_cooccurrence(corpus, attr_name, labeled_docs,
                 Q[index, w_i.token] += label_weight * norm
             Q[index, index] += label_weight * (label_weight - 1) * norm
         else:
-            norm = 1 / (n_d * (n_d + 2 * K * smoothing - 1) + K * (K * smoothing - smoothing))
+            norm = 1 / (n_d * (n_d - 1) + 2 * n_d * K * smoothing + K * (K - 1) * smoothing**2)
             for i, w_i in enumerate(doc.tokens):
                 for j, w_j in enumerate(doc.tokens):
                     if i == j:
@@ -128,7 +128,7 @@ def build_labeled_cooccurrence(corpus, attr_name, labeled_docs,
                 for j in label_set.values():
                     if i == j:
                         continue
-                    Q[i, j] += norm * smoothing ** 2
+                    Q[i, j] += norm * smoothing**2
 
     return Q / D, sorted(label_set, key=label_set.get)
 


### PR DESCRIPTION
In normalization of unlabeled documents, our normalization factor wasn't accounting for the squared smoothing term for the labels X labels part of Q (bottom left corner).

Either making this change, or changing line 131 to not square would allow each unlabeled document's contribution to pre-normalized-Q to sum to 1, however, I felt like the squaring on 131 was intentional, and is explained as follows:

Similar to label_weight for labeled documents, each unlabeled document has a 'smoothing'-amount of each label (currently defaulting at 1e-7), thus as the labels interact with each other, we have a 'smoothing-squared'-amount of co-occurrence.
(1e-7 th of a label co-occurred with 1e-7 th of another label)

Note that I've also factored the norm term here to make it more readable:
(With `K` as the count of labels and `n_d` as number of tokens in document d)

- `n_d * (n_d - 1)` Accounts for upper left side of Q

- `2 * n_d * K * smoothing` Accounts for the right and bottom of Q

- `K * (K - 1 ) * smoothing**2` Accounts for the bottom-right corner of Q




