### PR TITLE
Fixed one-token documents

### DIFF
--- a/ankura/anchor.py
+++ b/ankura/anchor.py
@@ -99,8 +99,6 @@ def build_labeled_cooccurrence(corpus, attr_name, labeled_docs,
     D = 0
     for d, doc in enumerate(corpus.documents):
         n_d = len(doc.tokens)
-        if n_d <= 1:
-            continue
         D += 1
 
         if d in labeled_docs:


### PR DESCRIPTION
Although documents with just one token don't have cooccurrence with other tokens, they still have cooccurrence with the document's label (or with the smoothing, for unlabeled documents).